### PR TITLE
Updating to 1.7.9 (getName changed to getUniqueId)

### DIFF
--- a/src/com/iCo6/command/Parser.java
+++ b/src/com/iCo6/command/Parser.java
@@ -352,7 +352,7 @@ public class Parser {
             this.value = value;
         }
 
-        public String getName() {
+        public String getUniqueId() {
             return name;
         }
 


### PR DESCRIPTION
Changed:

```
     public String getName() {
        return name;
    }
```

To:
        public String getUniqueId() {
            return name;
        }
